### PR TITLE
Update database urls when domain name doesn't match site url

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,7 +132,7 @@
 
 - name: (WordPress) Replace all site urls in database if changed
   command: >-
-    wp search-replace "{{ siteurl.stdout }}" "{{ wp_protocol }}{{ site_domain }}"
+    wp search-replace "{{ siteurl.stdout }}" "{{ wp_protocol }}{{ site_domain }}" --skip-columns=guid
   become: true
   become_user: wordpress
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,6 +127,7 @@
   become: true
   become_user: wordpress
   register: siteurl
+  changed_when: false
   args:
     chdir: "{{ wp_system_path }}"
 
@@ -136,8 +137,8 @@
   become: true
   become_user: wordpress
   args:
-    chdir: {{ wp_system_path }}
-  when: siteurl.stdout is defined and siteurl.stdout != "{{ wp_protocol }}{{ site_domain }}"
+    chdir: "{{ wp_system_path }}"
+  when: siteurl.stdout is defined and siteurl.stdout != wp_protocol + site_domain
   vars:
     wp_protocol: >-
       {{ "https://"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,6 +121,30 @@
   include: "wordpress.yml"
   when: wordpress_installed.changed
 
+- name: (WordPress) Get WordPress Site Url
+  command: >-
+    wp option get siteurl
+  become: true
+  become_user: wordpress
+  register: siteurl
+  args:
+    chdir: "{{ wp_system_path }}"
+
+- name: (WordPress) Replace all site urls in database if changed
+  command: >-
+    wp search-replace "{{ siteurl.stdout }}" "{{ wp_protocol }}{{ site_domain }}"
+  become: true
+  become_user: wordpress
+  args:
+    chdir: {{ wp_system_path }}
+  when: siteurl.stdout is defined and siteurl.stdout != "{{ wp_protocol }}{{ site_domain }}"
+  vars:
+    wp_protocol: >-
+      {{ "https://"
+      if use_letsencrypt is defined
+      and use_letsencrypt
+      else "http://" }}
+
 - name: (WordPress) Ensure WordPress siteurl and homeurl are correct
   command: >-
     wp option set {{ item }} "{{ wp_protocol }}{{ site_domain }}"


### PR DESCRIPTION
When the playbook is run with the intention of changing the domain the posts are not updated.

This change updates the post with the new site url if it differs from the previous url.