### PR TITLE
NGX-243: allow host ip in purge location block

### DIFF
--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -88,6 +88,7 @@ server {
 {% if nginx_cache_purge_enable %}
     location ~ ^/purge(/.*) {
         allow 127.0.0.1;
+        allow {{ ansible_default_ipv4.address }};
         deny all;
         proxy_cache_purge sitecache "$scheme$request_method$host$1";
     }


### PR DESCRIPTION
- allow host ip in purge location block.  Allows usutil to purge cache as well as NGINX Helper Plugin