### PR TITLE
NGX-254: import of nginx_proxy role task given profile tag

### DIFF
--- a/tasks/ultrastack.yml
+++ b/tasks/ultrastack.yml
@@ -9,6 +9,7 @@
   include_role:
     name: inmotionhosting.nginx_proxy
     public: yes
+  tags: profile
 
 - name: Load in profile variables for selected nginx cache profile
   include_vars:


### PR DESCRIPTION
- Run the nginx_proxy role tasks when runnning the playbook with the profile tag