### PR TITLE
NGX-262: bypass proxy cache if certain cookies are present

### DIFF
--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -43,6 +43,9 @@ server {
 {% if not nginx_proxy_cache_enable %}
         proxy_no_cache 1;
         proxy_cache_bypass 1;
+{% else %}
+        proxy_no_cache $cache_bypass;
+        proxy_cache_bypass $cache_bypass;
 {% endif %}
 {% if use_letsencrypt is defined and use_letsencrypt %}
         proxy_pass https://localhost:8443;


### PR DESCRIPTION
- $cache_bypass was being set if certain cookies were present, but not actually used.  Added usage of that variable in main location block to prevent caching of pages when user navigates website and certain cookies are present.