### PR TITLE
NGX-266: accept HTTP/2 connections

### DIFF
--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -4,7 +4,7 @@
 server {
     listen 80;
 {% if use_letsencrypt is defined and use_letsencrypt %}
-    listen 443 ssl;
+    listen 443 ssl http2;
     ssl_certificate     /etc/letsencrypt/live/{{ site_domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ site_domain }}/privkey.pem;
 {% endif %}


### PR DESCRIPTION
- accept HTTP/2 connections.  NGINX from epel is built with the --with-http_v2_module configuration parameter.