### PR TITLE
NGX-265: set nginx_accel_static_content=false for all profiles

### DIFF
--- a/vars/nginx_cache_profiles/honor_headers.yml
+++ b/vars/nginx_cache_profiles/honor_headers.yml
@@ -1,4 +1,4 @@
-nginx_accel_static_content: true
+nginx_accel_static_content: false
 nginx_cache_convert_head: true
 nginx_cache_honor_cc: true
 nginx_cache_honor_cookies: true

--- a/vars/nginx_cache_profiles/no_caching.yml
+++ b/vars/nginx_cache_profiles/no_caching.yml
@@ -1,4 +1,4 @@
-nginx_accel_static_content: true
+nginx_accel_static_content: false
 nginx_cache_convert_head: true
 nginx_cache_honor_cc: false
 nginx_cache_honor_cookies: true

--- a/vars/nginx_cache_profiles/wordpress.yml
+++ b/vars/nginx_cache_profiles/wordpress.yml
@@ -1,4 +1,4 @@
-nginx_accel_static_content: true
+nginx_accel_static_content: false
 nginx_cache_convert_head: true
 nginx_cache_honor_cc: false
 nginx_cache_honor_cookies: true

--- a/vars/nginx_cache_profiles/wordpress_microcache.yml
+++ b/vars/nginx_cache_profiles/wordpress_microcache.yml
@@ -1,4 +1,4 @@
-nginx_accel_static_content: true
+nginx_accel_static_content: false
 nginx_cache_convert_head: true
 nginx_cache_honor_cc: false
 nginx_cache_honor_cookies: true


### PR DESCRIPTION
- Having NGINX serve static content directly is causing issues with the Total Cache Plugin.  We can add a toggle to the UI later if a customer wants to enable it, and is aware of the side effects.