### PR TITLE
NGX-257: restart nginx when changes are made to site.conf

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
 
 - name: restart nginx
   service:
-    name: "{{ nginx_daemon }}"
+    name: nginx
     state: restarted


### PR DESCRIPTION
- Not all the profile changes cause proxy.conf to update, so we also need to define/trigger an nginx restart handler from within this role if site.conf changes.