### PR TITLE
NGX-274: make no_caching the default NGINX cache profile

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,7 @@ nginx_brotli_comp_level: 4
 #
 # Nginx Cache Profile
 #
-nginx_cache_profile: wordpress
+nginx_cache_profile: no_caching
 
 # The system user that the WordPress site will belong to.
 system_user: "wordpress"


### PR DESCRIPTION
- To prevent issues during initial transfer/setup it is preferable to have NGINX caching disabled.  The user will be prompted in the application under a "to-do list" to enable the NGINX caching.