### PR TITLE
NGX-289: remove extra nginx site configs

### DIFF
--- a/tasks/ultrastack.yml
+++ b/tasks/ultrastack.yml
@@ -38,6 +38,21 @@
     - nginx_vts_enable is defined
     - nginx_vts_enable
 
+- name: Identify extra site configs
+  ansible.builtin.find:
+    paths: /etc/nginx/conf.d
+    file_type: file
+    contains: '.*site\.conf\.j2.*'
+    excludes: "{{ site_domain }}.conf"
+  register: nginx_extra_sites
+
+- name: Remove extra site configs
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ nginx_extra_sites.files }}"
+  notify: restart nginx
+
 #
 # Redis
 #

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -1,5 +1,7 @@
 # {{ template_destpath }}
 # {{ ansible_managed }}
+# tags: site.conf.j2
+
 
 upstream http_backend {
 {% if use_letsencrypt is defined and use_letsencrypt %}


### PR DESCRIPTION
- Remove any extra site configs for a different site_domain used in a previous playbook run.  This is also necessary to prevent duplicate upstream blocks with the same name.