### PR TITLE
NGX-380: Always trigger apache/php-fpm restart handlers

### DIFF
--- a/tasks/ultrastack.yml
+++ b/tasks/ultrastack.yml
@@ -54,6 +54,8 @@
   notify: restart nginx
 
 - name: Reload nginx
+  debug:
+    msg: "trigger nginx restart"
   changed_when: true
   notify: restart nginx
 

--- a/tasks/ultrastack.yml
+++ b/tasks/ultrastack.yml
@@ -53,6 +53,10 @@
   with_items: "{{ nginx_extra_sites.files }}"
   notify: restart nginx
 
+- name: Reload nginx
+  changed_when: true
+  notify: restart nginx
+
 #
 # Redis
 #


### PR DESCRIPTION
- Certain circumstances cause the playbook to apply changes without restarting the service. Subsequent runs do not apply any changes, so the service is again not restarted. This can cause service to be stuck in running state with outdated configs which playbook can not correct. For this reason, we notify the apache, php-fpm, and nginx restart handlers on every run.