### PR TITLE
NGX-731: move upstream config to separate conf file

### DIFF
--- a/tasks/ultrastack.yml
+++ b/tasks/ultrastack.yml
@@ -16,6 +16,15 @@
     file: vars/nginx_cache_profiles/{{ nginx_cache_profile }}.yml
   tags: profile
 
+- name: Configure upstream server groups
+  template:
+    src: etc/nginx/conf.d/upstream.conf.j2
+    dest: /etc/nginx/conf.d/upstream.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart nginx
+
 - name: Configure site-specific NGINX proxy
   template:
     src: etc/nginx/conf.d/site.conf.j2

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -3,15 +3,6 @@
 # tags: site.conf.j2
 
 
-upstream http_backend {
-{% if use_letsencrypt is defined and use_letsencrypt|bool %}
-    server 127.0.0.1:8443;
-{% else %}
-    server 127.0.0.1:8080;
-{% endif %}    
-    keepalive 2;
-}
-
 server {
     listen 80;
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}

--- a/templates/etc/nginx/conf.d/upstream.conf.j2
+++ b/templates/etc/nginx/conf.d/upstream.conf.j2
@@ -1,0 +1,12 @@
+# {{ template_destpath }}
+# {{ ansible_managed }}
+
+
+upstream http_backend {
+{% if use_letsencrypt is defined and use_letsencrypt|bool %}
+    server 127.0.0.1:8443;
+{%- else %}
+    server 127.0.0.1:8080;
+{%- endif %}    
+    keepalive 2;
+}


### PR DESCRIPTION
- Move the upstream configuration block out of the site config template, so that there is a lower chance that it gets duplicated and causes a nginx config syntax error.