### PR TITLE
NGX-733: do not remove site configs that match given patterns

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,3 +54,7 @@ wp_system_path: "/home/{{ system_user }}/{{ wp_system_folder }}"
 
 # metavar that helps control some tasks that should not run
 install_wordpress: true
+
+# site config conf files matching these patterns will not be removed from /etc/nginx/conf.d/
+preserve_site_config_patterns:
+  - "{{ site_domain }}.conf"

--- a/tasks/ultrastack.yml
+++ b/tasks/ultrastack.yml
@@ -16,6 +16,15 @@
     file: vars/nginx_cache_profiles/{{ nginx_cache_profile }}.yml
   tags: profile
 
+- name: Configure upstream server groups
+  template:
+    src: etc/nginx/conf.d/upstream.conf.j2
+    dest: /etc/nginx/conf.d/upstream.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart nginx
+
 - name: Configure site-specific NGINX proxy
   template:
     src: etc/nginx/conf.d/site.conf.j2

--- a/tasks/ultrastack.yml
+++ b/tasks/ultrastack.yml
@@ -52,7 +52,7 @@
     paths: /etc/nginx/conf.d
     file_type: file
     contains: '.*site\.conf\.j2.*'
-    excludes: "{{ site_domain }}.conf"
+    excludes: "{{ preserve_site_config_patterns }}"
   register: nginx_extra_sites
 
 - name: Remove extra site configs

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -3,15 +3,6 @@
 # tags: site.conf.j2
 
 
-upstream http_backend {
-{% if use_letsencrypt is defined and use_letsencrypt|bool %}
-    server 127.0.0.1:8443;
-{% else %}
-    server 127.0.0.1:8080;
-{% endif %}    
-    keepalive 2;
-}
-
 server {
     listen 80;
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}


### PR DESCRIPTION
- Changing the site's url creates new nginx and apache config files for the new domain.  We've been removing everything except the newest one.  This new feature allows us the user to exclude removal of any site configs that match the provided patterns.  This way we can persist the configs for the server hostname itself.